### PR TITLE
Fix Netlify build config

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ This contains everything you need to run your app locally.
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Build for production
+
+Run `npm run build` to generate the static files in the `dist` folder. Deploy this directory along with the `netlify/functions` folder to Netlify.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+  command = "npm run build"
+  publish = "dist"
+  functions = "netlify/functions"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,23 @@
   "version": "1.0.0",
   "description": "Una aplicación web interactiva y educativa sobre funciones matemáticas.",
   "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
   "dependencies": {
-    "@google/genai": "^0.15.0"
+    "@google/genai": "^0.15.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "recharts": "^2.7.2",
+    "mathlive": "^0.96.0"
+  },
+  "devDependencies": {
+    "vite": "^5.2.0",
+    "@vitejs/plugin-react": "^4.2.0",
+    "typescript": "^5.4.0",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0"
   }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,11 @@
 import path from 'path';
 import { defineConfig, loadEnv } from 'vite';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+      plugins: [react()],
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)


### PR DESCRIPTION
## Summary
- add npm scripts and dependencies for a Vite React project
- enable React plugin in `vite.config.ts`
- configure Netlify to run the proper build command
- document the production build instructions

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*
- `npm run build` *(fails: vite not found because dependencies couldn't be installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e9d3fe4e4832e8f66ab912c68fb97