### PR TITLE
Fix missing module for Netlify build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.env.local
+

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recharts": "^2.7.2",
-    "mathlive": "^0.96.0"
+    "mathlive": "^0.96.0",
+    "react-latex-next": "^2.16.0"
   },
   "devDependencies": {
     "vite": "^5.2.0",


### PR DESCRIPTION
## Summary
- ignore build and environment files
- add `react-latex-next` as a dependency

## Testing
- ❌ `npm run build` *(fails: npm registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685ea09fa924832ea03b17b85024a947