### PR TITLE
Fix build by using available react-latex-next version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^18.2.0",
     "recharts": "^2.7.2",
     "mathlive": "^0.96.0",
-    "react-latex-next": "^2.16.0"
+    "react-latex-next": "^3.0.0"
   },
   "devDependencies": {
     "vite": "^5.2.0",


### PR DESCRIPTION
## Summary
- fix build by updating `react-latex-next` dependency

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea1d8cec4832e8edcf9ed0c309981