### PR TITLE
Add general chat bot and topic selection

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,6 +4,7 @@ import Header from './components/Header';
 import FunctionView from './components/FunctionView';
 import CalculatorView from './components/CalculatorView';
 import AITutorView from './components/AITutorView';
+import DoubtsChatView from './components/DoubtsChatView';
 import { SectionId, FunctionType } from './types';
 import { SECTION_DEFINITIONS, PROBLEMS_DATA, THEORY_DATA } from './constants';
 
@@ -34,8 +35,10 @@ const App: React.FC = () => {
           />
         ) : currentSection === 'calculadora' ? (
           <CalculatorView />
-        ) : (
+        ) : currentSection === 'tutor_ia' ? (
           <AITutorView />
+        ) : (
+          <DoubtsChatView />
         )}
       </main>
       <footer className="text-center py-4 text-slate-500 dark:text-slate-400 text-sm">

--- a/components/AITutorView.tsx
+++ b/components/AITutorView.tsx
@@ -10,6 +10,7 @@ import MathInput from './ui/MathInput';
 const AITutorView: React.FC = () => {
     const { messages, loading, error, sendMessage } = useAITutor();
     const [input, setInput] = useState('');
+    const [topic, setTopic] = useState('Álgebra');
     const [imageFile, setImageFile] = useState<File | null>(null);
     const [imagePreview, setImagePreview] = useState<string | null>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -21,7 +22,7 @@ const AITutorView: React.FC = () => {
     
     const submitMessage = () => {
         if (loading || (!input.trim() && !imageFile)) return;
-        sendMessage(input, imageFile ?? undefined);
+        sendMessage(input, topic, imageFile ?? undefined);
         setInput('');
         setImageFile(null);
         setImagePreview(null);
@@ -87,9 +88,18 @@ const AITutorView: React.FC = () => {
                         <button onClick={() => { setImageFile(null); setImagePreview(null); if(fileInputRef.current) fileInputRef.current.value = ''; }} className="absolute -top-2 -right-2 bg-red-500 text-white rounded-full w-6 h-6 flex items-center justify-center text-xs shadow-lg">&times;</button>
                     </div>
                  )}
-                <form onSubmit={handleFormSubmit} className="flex items-center gap-2">
+                <form onSubmit={handleFormSubmit} className="flex flex-wrap items-center gap-2">
                     <input type="file" ref={fileInputRef} onChange={handleFileChange} accept="image/*" className="hidden" />
                     <Button type="button" variant="secondary" onClick={triggerFileSelect} icon={ICONS.upload} aria-label="Subir imagen" />
+                    <select
+                        value={topic}
+                        onChange={(e) => setTopic(e.target.value)}
+                        className="px-3 py-2 bg-white dark:bg-slate-700 border border-slate-300 dark:border-slate-600 rounded-md text-sm focus:outline-none focus:border-primary focus:ring-1 focus:ring-primary"
+                    >
+                        {['Álgebra','Geometría','Cálculo','Estadística','Otro'].map(t => (
+                            <option key={t} value={t}>{t}</option>
+                        ))}
+                    </select>
                     <MathInput
                         value={input}
                         onChange={setInput}

--- a/components/DoubtsChatView.tsx
+++ b/components/DoubtsChatView.tsx
@@ -1,0 +1,72 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { useDoubts } from '../hooks/useDoubts';
+import Card from './ui/Card';
+import Button from './ui/Button';
+import MathInput from './ui/MathInput';
+import LatexDisplay from './Latex';
+import { ChatMessage } from '../types';
+import { ICONS } from '../constants';
+
+const DoubtsChatView: React.FC = () => {
+  const { messages, loading, error, sendMessage } = useDoubts();
+  const [input, setInput] = useState('');
+  const chatEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    chatEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const submit = () => {
+    if (loading || !input.trim()) return;
+    sendMessage(input);
+    setInput('');
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    submit();
+  };
+
+  const ChatBubble: React.FC<{ message: ChatMessage }> = ({ message }) => {
+    const isUser = message.role === 'user';
+    return (
+      <div className={`flex items-end gap-2 ${isUser ? 'justify-end' : 'justify-start'}`}>\
+        <div className={`max-w-xl p-3 rounded-lg shadow-sm ${isUser ? 'bg-primary text-white' : 'bg-slate-200 dark:bg-slate-700'}`}>\
+          <LatexDisplay as="div" className="text-left">{message.text}</LatexDisplay>\
+        </div>\
+      </div>
+    );
+  };
+
+  return (
+    <Card className="flex flex-col h-[calc(100vh-12rem)]">
+      <div className="p-4 border-b border-slate-200 dark:border-slate-700">
+        <h2 className="text-xl font-bold text-primary">Chat de Dudas</h2>
+        <p className="text-sm text-slate-500 dark:text-slate-400">Consulta cualquier duda de forma natural.</p>
+      </div>
+      <div className="flex-1 p-4 overflow-y-auto space-y-4 bg-slate-50 dark:bg-slate-800/50">
+        <ChatBubble message={{ role: 'model', text: '¡Hola! ¿En qué puedo ayudarte hoy?' }} />
+        {messages.map((m, i) => <ChatBubble key={i} message={m} />)}
+        {loading && (
+          <div className="flex justify-start">
+            <div className="p-3 rounded-lg bg-slate-200 dark:bg-slate-700 flex items-center gap-2">
+              <div className="w-2 h-2 bg-slate-500 rounded-full animate-bounce [animation-delay:-0.3s]"></div>
+              <div className="w-2 h-2 bg-slate-500 rounded-full animate-bounce [animation-delay:-0.15s]"></div>
+              <div className="w-2 h-2 bg-slate-500 rounded-full animate-bounce"></div>
+            </div>
+          </div>
+        )}
+        {error && <div className="text-red-500">{error}</div>}
+        <div ref={chatEndRef} />
+      </div>
+      <div className="p-4 border-t border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
+        <form onSubmit={handleSubmit} className="flex items-center gap-2">
+          <MathInput value={input} onChange={setInput} onEnter={submit} placeholder="Escribe tu duda..." />
+          <Button type="submit" disabled={loading || !input.trim()} icon={ICONS.send} aria-label="Enviar" />
+        </form>
+      </div>
+    </Card>
+  );
+};
+
+export default DoubtsChatView;

--- a/constants.tsx
+++ b/constants.tsx
@@ -8,6 +8,7 @@ export const SECTION_DEFINITIONS: SectionDefinition[] = [
   { name: 'Funciones Logarítmicas', id: 'logaritmica' },
   { name: 'Calculadora Gráfica', id: 'calculadora' },
   { name: 'Tutor con IA', id: 'tutor_ia' },
+  { name: 'Chat de Dudas', id: 'dudas_chat' },
 ];
 
 export const THEORY_DATA: TheorySet = {

--- a/hooks/useAITutor.ts
+++ b/hooks/useAITutor.ts
@@ -7,20 +7,20 @@ export const useAITutor = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const sendMessage = async (prompt: string, imageFile?: File) => {
+  const sendMessage = async (prompt: string, topic: string, imageFile?: File) => {
     if (!prompt && !imageFile) return;
 
     setLoading(true);
     setError(null);
 
-    const userMessage: ChatMessage = { role: 'user', text: prompt };
+    const userMessage: ChatMessage = { role: 'user', text: `${topic}: ${prompt}` };
     if (imageFile) {
       userMessage.image = URL.createObjectURL(imageFile);
     }
     setMessages(prev => [...prev, userMessage]);
 
     try {
-      const body: { prompt: string; image?: { base64: string; mimeType: string; } } = { prompt };
+      const body: { prompt: string; topic: string; image?: { base64: string; mimeType: string; } } = { prompt, topic };
 
       if (imageFile) {
         const base64Image = await fileToBase64(imageFile);

--- a/hooks/useDoubts.ts
+++ b/hooks/useDoubts.ts
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { ChatMessage } from '../types';
+
+export const useDoubts = () => {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const sendMessage = async (prompt: string) => {
+    if (!prompt) return;
+    setLoading(true);
+    setError(null);
+    const userMessage: ChatMessage = { role: 'user', text: prompt };
+    setMessages(prev => [...prev, userMessage]);
+    try {
+      const response = await fetch('/.netlify/functions/doubts', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt }),
+      });
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({ error: `Request failed with status ${response.status}` }));
+        throw new Error(errData.error || `Request failed with status ${response.status}`);
+      }
+      const result = await response.json();
+      const modelResponse: ChatMessage = { role: 'model', text: result.text };
+      setMessages(prev => [...prev, modelResponse]);
+    } catch (e) {
+      console.error(e);
+      const errorMessage = e instanceof Error ? e.message : 'Ocurrió un error desconocido.';
+      setError(errorMessage);
+      setMessages(prev => [...prev, { role: 'model', text: `Lo siento, no pude procesar tu solicitud. ${errorMessage}` }]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return { messages, loading, error, sendMessage };
+};

--- a/netlify/functions/doubts.ts
+++ b/netlify/functions/doubts.ts
@@ -1,0 +1,47 @@
+import { GoogleGenAI, GenerateContentResponse } from '@google/genai';
+
+interface DoubtRequestBody {
+  prompt: string;
+}
+
+export const handler = async (event: { httpMethod: string; body: string | null }) => {
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      body: JSON.stringify({ error: 'Method Not Allowed' }),
+    };
+  }
+
+  const API_KEY = process.env.API_KEY;
+  if (!API_KEY) {
+    return { statusCode: 500, body: JSON.stringify({ error: 'API key not configured on server.' }) };
+  }
+
+  try {
+    const body: DoubtRequestBody = JSON.parse(event.body || '{}');
+    const { prompt } = body;
+    if (!prompt) {
+      return { statusCode: 400, body: JSON.stringify({ error: 'Prompt is required.' }) };
+    }
+
+    const ai = new GoogleGenAI({ apiKey: API_KEY });
+    const response: GenerateContentResponse = await ai.models.generateContent({
+      model: 'gemini-2.5-flash-preview-04-17',
+      contents: [{ text: prompt }],
+      config: {
+        systemInstruction: 'Eres un asistente conversacional amistoso. Responde en español de forma natural y ayuda a aclarar dudas del usuario.',
+      },
+    });
+
+    const text = response.text;
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ text }),
+      headers: { 'Content-Type': 'application/json' },
+    };
+  } catch (e) {
+    console.error('Error calling Gemini API:', e);
+    const errorMessage = e instanceof Error ? e.message : 'An unknown error occurred.';
+    return { statusCode: 500, body: JSON.stringify({ error: `Error processing request: ${errorMessage}` }) };
+  }
+};

--- a/netlify/functions/tutor.ts
+++ b/netlify/functions/tutor.ts
@@ -2,6 +2,7 @@ import { GoogleGenAI, GenerateContentResponse } from '@google/genai';
 
 interface TutorRequestBody {
     prompt: string;
+    topic: string;
     image?: {
         base64: string;
         mimeType: string;
@@ -28,7 +29,7 @@ export const handler = async (event: { httpMethod: string; body: string | null; 
 
     try {
         const body: TutorRequestBody = JSON.parse(event.body || '{}');
-        const { prompt, image } = body;
+        const { prompt, topic, image } = body;
 
         if (!prompt && !image) {
             return {
@@ -56,7 +57,7 @@ export const handler = async (event: { httpMethod: string; body: string | null; 
             model: 'gemini-2.5-flash-preview-04-17',
             contents: { parts },
             config: {
-                systemInstruction: "Eres un amigable y experto tutor de matemáticas. Tu objetivo es ayudar a los estudiantes a entender conceptos, no solo darles la respuesta. Explica los pasos de forma clara y pedagógica. Utiliza LaTeX para las fórmulas, por ejemplo, para escribir $x^2 + 5$, usa `$x^2 + 5$."
+                systemInstruction: `Eres un amigable y experto tutor de matemáticas especializado en ${topic}. Tu objetivo es ayudar a los estudiantes a entender conceptos, no solo darles la respuesta. Explica los pasos de forma clara y pedagógica. Utiliza LaTeX para las fórmulas, por ejemplo, para escribir $x^2 + 5$, usa \`$x^2 + 5$\`.`,
             }
         });
         

--- a/types.ts
+++ b/types.ts
@@ -1,6 +1,6 @@
 
 export type FunctionType = 'cuadratica' | 'exponencial' | 'logaritmica';
-export type SectionId = FunctionType | 'calculadora' | 'tutor_ia';
+export type SectionId = FunctionType | 'calculadora' | 'tutor_ia' | 'dudas_chat';
 
 export interface SectionDefinition {
   name: string;


### PR DESCRIPTION
## Summary
- add new `dudas_chat` section and navigation entry
- create `DoubtsChatView` component with its hook and Netlify function
- update AI tutor to include problem topic selection
- send selected topic to server and tailor system instruction

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea5207408832ea7f80642df9c1ef3