### PR TITLE
Fix LaTeX display and add modern styling

### DIFF
--- a/components/Latex.tsx
+++ b/components/Latex.tsx
@@ -10,9 +10,24 @@ interface LatexDisplayProps {
 
 const LatexDisplay: React.FC<LatexDisplayProps> = ({ children, className = '', as = 'span' }) => {
   const Component = as;
+
+  const parts = children.split(/(\$[^$]*\$)/g);
+
+  const renderPart = (part: string, index: number) => {
+    if (part.startsWith('$') && part.endsWith('$')) {
+      return <Latex key={index}>{part}</Latex>;
+    }
+
+    const html = part
+      .replace(/\\textbf\{([^}]*)\}/g, '<strong>$1</strong>')
+      .replace(/\\textit\{([^}]*)\}/g, '<em>$1</em>');
+
+    return <span key={index} dangerouslySetInnerHTML={{ __html: html }} />;
+  };
+
   return (
     <Component className={`latex-container ${className}`}>
-      <Latex>{children}</Latex>
+      {parts.map((p, i) => renderPart(p, i))}
     </Component>
   );
 };

--- a/index.css
+++ b/index.css
@@ -1,0 +1,11 @@
+body {
+  font-family: 'Inter', sans-serif;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: 'Merriweather', serif;
+}
+
+.latex-container {
+  line-height: 1.6;
+}

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-n8MVd4RsNIU0KOVEMVIARBEEDYwIWN5KksMLCDNifagMH8xGX3oGcpMPIodjTwFR" crossorigin="anonymous">
     <link rel="stylesheet" href="https://unpkg.com/mathlive/dist/mathlive.css" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&family=Merriweather:wght@700&display=swap" rel="stylesheet">
     <style>
       math-field {
         display: block;
@@ -43,13 +44,13 @@
           extend: {
             colors: {
               primary: {
-                DEFAULT: '#0284c7', // sky-600
-                light: '#03a9f4',   // light-blue-500
-                dark: '#01579b',   // light-blue-800
+                DEFAULT: '#1e40af', // indigo-800
+                light: '#3b82f6',   // blue-500
+                dark: '#1e3a8a',    // indigo-900
               },
-              secondary: '#475569', // slate-600
-              accent: '#10b981', // emerald-500
-              danger: '#ef4444', // red-500
+              secondary: '#374151', // gray-700
+              accent: '#d97706', // amber-600
+              danger: '#dc2626', // red-600
             },
           }
         }
@@ -72,7 +73,7 @@
 </script>
 <link rel="stylesheet" href="/index.css">
 </head>
-<body class="bg-slate-100 dark:bg-slate-900 text-slate-800 dark:text-slate-200">
+<body class="bg-slate-100 dark:bg-slate-900 text-slate-800 dark:text-slate-200 font-sans">
     <div id="root"></div>
     <script type="module" src="/index.tsx"></script>
 </body>


### PR DESCRIPTION
## Summary
- preprocess LaTeX text to support \textbf and \textit outside math environments
- add professional fonts and theme colors
- create a CSS file for new fonts

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea8f5ed34832e9155df32e6b9a0bd