### PR TITLE
Add rational function type

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,8 +15,15 @@ const App: React.FC = () => {
     setCurrentSection(sectionId);
   };
 
+  const functionSectionIds: FunctionType[] = SECTION_DEFINITIONS
+    .map(def => def.id)
+    .filter(
+      (secId): secId is FunctionType =>
+        secId !== 'calculadora' && secId !== 'tutor_ia' && secId !== 'dudas_chat'
+    );
+
   const isFunctionSection = (id: SectionId): id is FunctionType => {
-    return ['cuadratica', 'exponencial', 'logaritmica'].includes(id);
+    return functionSectionIds.includes(id as FunctionType);
   };
 
   return (

--- a/components/CalculatorView.tsx
+++ b/components/CalculatorView.tsx
@@ -31,12 +31,23 @@ const calculatorConfigs: Record<FunctionType, { params: Record<string, number>, 
         ],
         plotConfig: { type: 'logarithmic', params: ['b'], domain: [0.1, 10] }
     },
+    racional: {
+        params: { a: 1, b: 0, c: 1, d: 0 },
+        controls: [
+            { param: 'a', min: -5, max: 5, step: 0.1 },
+            { param: 'b', min: -10, max: 10, step: 0.5 },
+            { param: 'c', min: -5, max: 5, step: 0.1 },
+            { param: 'd', min: -10, max: 10, step: 0.5 },
+        ],
+        plotConfig: { type: 'rational', params: ['a','b','c','d'], domain: [-10, 10] }
+    },
 };
 
 const functionNames: Record<FunctionType, string> = {
     cuadratica: 'Cuadrática: $f(x) = ax^2 + bx + c$',
     exponencial: 'Exponencial: $f(x) = a \\cdot b^x$',
-    logaritmica: 'Logarítmica: $f(x) = \\log_b(x)$'
+    logaritmica: 'Logarítmica: $f(x) = \\log_b(x)$',
+    racional: 'Racional: $f(x)=\\frac{ax+b}{cx+d}$'
 };
 
 const CalculatorView: React.FC = () => {
@@ -75,6 +86,7 @@ const CalculatorView: React.FC = () => {
                         <option value="cuadratica">Función Cuadrática</option>
                         <option value="exponencial">Función Exponencial</option>
                         <option value="logaritmica">Función Logarítmica</option>
+                        <option value="racional">Función Racional</option>
                     </select>
                  </div>
 

--- a/constants.tsx
+++ b/constants.tsx
@@ -6,6 +6,7 @@ export const SECTION_DEFINITIONS: SectionDefinition[] = [
   { name: 'Funciones Cuadráticas', id: 'cuadratica' },
   { name: 'Funciones Exponenciales', id: 'exponencial' },
   { name: 'Funciones Logarítmicas', id: 'logaritmica' },
+  { name: 'Funciones Racionales', id: 'racional' },
   { name: 'Calculadora Gráfica', id: 'calculadora' },
   { name: 'Tutor con IA', id: 'tutor_ia' },
   { name: 'Chat de Dudas', id: 'dudas_chat' },
@@ -57,6 +58,17 @@ export const THEORY_DATA: TheorySet = {
       { term: 'Punto Clave de Paso', description: 'Toda función exponencial $b^y$ cumple que si $y=0$, entonces $b^0 = 1$. Llevando esto a su inversa, el logaritmo, significa que $\\log_b(1) = 0$ para cualquier base $\\mathbf{b}$. Esto nos da un punto de anclaje universal: toda función logarítmica básica pasa por el punto $\\mathbf{(1, 0)}$.' }
     ],
     videoUrl: 'https://www.youtube.com/embed/C0vUje9Uduc'
+  },
+  racional: {
+    title: 'Introducción a las Funciones Racionales',
+    paragraphs: [
+      'Una función racional es el cociente de dos polinomios. Su forma general puede escribirse como $f(x)=\\frac{ax+b}{cx+d}$.',
+      'Ejemplos típicos son $f(x)=\\tfrac{x+5}{x+4}$, $g(x)=\\tfrac{x+1}{x-3}$ y $h(x)=\\tfrac{x}{x-10}$.',
+      'Estas funciones presentan puntos donde el denominador se anula; allí la función no está definida y suele mostrarse una asíntota vertical.'
+    ],
+    properties: [
+      { term: 'Dominio', description: 'El dominio incluye todos los valores reales excepto aquellos que hacen cero al denominador.' }
+    ]
   }
 };
 
@@ -308,6 +320,59 @@ export const PROBLEMS_DATA: ProblemSet = {
       },
       inputs: [{ id: 'lim_inf', label: 'Límite inferior:', type: 'number' }],
       plot: { type: 'logarithmic', params: ['b'], domain: [1, 8], interactiveControls: [ { param: 'b', min: 1.1, max: 5, step: 0.1 } ] }
+    }
+  ],
+  racional: [
+    {
+      id: 1,
+      enunciado: 'Para la función $f(x)=\\tfrac{x+5}{x+4}$, calcula $f(2)$.',
+      funcParams: { a: 1, b: 5, c: 1, d: 4 },
+      solution: {
+        type: 'evaluar_funcion_racional',
+        pasos: [
+          'Sustituimos $x=2$ en la expresión: $f(2)=\\tfrac{2+5}{2+4}$.',
+          'Calculamos numerador y denominador: $7$ y $6$.',
+          'Dividimos: $\\tfrac{7}{6} \approx 1.17$.'
+        ],
+        correctAnswers: { valor_y: 7/6 }
+      },
+      inputs: [{ id: 'valor_y', label: '$f(2) = $', type: 'number' }],
+      plot: {
+        type: 'rational',
+        params: ['a','b','c','d'],
+        domain: [-6,6],
+        interactiveControls: [
+          { param: 'a', min: -5, max: 5, step: 0.5 },
+          { param: 'b', min: -10, max: 10, step: 0.5 },
+          { param: 'c', min: -5, max: 5, step: 0.5 },
+          { param: 'd', min: -10, max: 10, step: 0.5 }
+        ]
+      }
+    },
+    {
+      id: 2,
+      enunciado: '¿Qué valor de $x$ hace que $g(x)=\\tfrac{x+1}{x-3}$ no esté definida?',
+      funcParams: { a: 1, b: 1, c: 1, d: -3 },
+      solution: {
+        type: 'valor_excluido',
+        pasos: [
+          'Una función racional no está definida cuando su denominador es cero.',
+          'Resolvemos $x-3=0$ y obtenemos $x=3$.'
+        ],
+        correctAnswers: { x: 3 }
+      },
+      inputs: [{ id: 'x', label: '$x = $', type: 'number' }],
+      plot: {
+        type: 'rational',
+        params: ['a','b','c','d'],
+        domain: [-6,6],
+        interactiveControls: [
+          { param: 'a', min: -5, max: 5, step: 0.5 },
+          { param: 'b', min: -10, max: 10, step: 0.5 },
+          { param: 'c', min: -5, max: 5, step: 0.5 },
+          { param: 'd', min: -10, max: 10, step: 0.5 }
+        ]
+      }
     }
   ]
 };

--- a/types.ts
+++ b/types.ts
@@ -1,5 +1,5 @@
 
-export type FunctionType = 'cuadratica' | 'exponencial' | 'logaritmica';
+export type FunctionType = 'cuadratica' | 'exponencial' | 'logaritmica' | 'racional';
 export type SectionId = FunctionType | 'calculadora' | 'tutor_ia' | 'dudas_chat';
 
 export interface SectionDefinition {
@@ -15,7 +15,7 @@ export interface InteractiveControl {
 }
 
 export interface PlotConfig {
-  type: 'parabola' | 'exponential' | 'logarithmic';
+  type: 'parabola' | 'exponential' | 'logarithmic' | 'rational';
   params: string[];
   domain: [number, number];
   interactiveControls?: InteractiveControl[];

--- a/utils/math.ts
+++ b/utils/math.ts
@@ -32,6 +32,15 @@ export const generatePlotPoints = (
           y = NaN; // Not in domain
         }
         break;
+      case 'rational':
+        const { a: ratA = 1, b: ratB = 0, c: ratC = 1, d: ratD = 0 } = params;
+        const denom = ratC * x + ratD;
+        if (denom !== 0) {
+          y = (ratA * x + ratB) / denom;
+        } else {
+          y = NaN;
+        }
+        break;
       default:
         y = NaN;
     }


### PR DESCRIPTION
## Summary
- support `racional` function type in constants and types
- add rational theory section and sample practice problems
- add plotting support for rational functions
- extend calculator to handle rational functions
- derive `isFunctionSection` dynamically from `SECTION_DEFINITIONS`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea7736704832ebb61130031745626