### PR TITLE
Update Google GenAI to consistent 1.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@google/genai": "^0.15.0",
+    "@google/genai": "^1.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recharts": "^2.7.2",


### PR DESCRIPTION
## Summary
- use v1.7.0 of `@google/genai` to match the import map

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@google%2fgenai)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb3400528832eb68094b666a32d65