### PR TITLE
Fix chat spaces by disabling math keyboard

### DIFF
--- a/components/DoubtsChatView.tsx
+++ b/components/DoubtsChatView.tsx
@@ -61,7 +61,13 @@ const DoubtsChatView: React.FC = () => {
       </div>
       <div className="p-4 border-t border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900">
         <form onSubmit={handleSubmit} className="flex items-center gap-2">
-          <MathInput value={input} onChange={setInput} onEnter={submit} placeholder="Escribe tu duda..." />
+          <MathInput
+            value={input}
+            onChange={setInput}
+            onEnter={submit}
+            placeholder="Escribe tu duda..."
+            useMathField={false}
+          />
           <Button type="submit" disabled={loading || !input.trim()} icon={ICONS.send} aria-label="Enviar" />
         </form>
       </div>

--- a/components/ui/MathInput.tsx
+++ b/components/ui/MathInput.tsx
@@ -30,10 +30,16 @@ interface MathInputProps {
   onChange: (value: string) => void;
   onEnter?: () => void;
   placeholder?: string;
+  /**
+   * When `true` (default) use the `math-field` element with the
+   * virtual math keyboard enabled. Set to `false` to render a
+   * plain text input instead.
+   */
+  useMathField?: boolean;
 }
 
-const MathInput: React.FC<MathInputProps> = ({ value, onChange, onEnter, placeholder }) => {
-  const mathfieldDefined = typeof window !== 'undefined' && !!customElements.get('math-field');
+const MathInput: React.FC<MathInputProps> = ({ value, onChange, onEnter, placeholder, useMathField = true }) => {
+  const mathfieldDefined = useMathField && typeof window !== 'undefined' && !!customElements.get('math-field');
   // The ref is typed as our augmented MathfieldElement to get type safety when mathlive is available.
   const mf = useRef<MathfieldElement>(null);
 


### PR DESCRIPTION
## Summary
- add optional `useMathField` prop to `MathInput` to allow a plain input
- disable the math keyboard only in `DoubtsChatView`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb6676330832ebd5de921bf11c00b