### PR TITLE
Restrict chat to math

### DIFF
--- a/netlify/functions/doubts.ts
+++ b/netlify/functions/doubts.ts
@@ -32,7 +32,10 @@ export const handler = async (event: { httpMethod: string; body: string | null }
       model: 'gemini-2.5-flash-preview-04-17',
       contents: [{ text: prompt }],
       config: {
-        systemInstruction: 'Eres un asistente conversacional amistoso. Responde en español de forma natural y ayuda a aclarar dudas del usuario.',
+        systemInstruction:
+          'Eres un asistente conversacional especializado en matemáticas. ' +
+          'Respondes exclusivamente preguntas y dudas sobre conceptos, ejercicios y temas matemáticos. ' +
+          'Si el usuario plantea algo fuera del ámbito matemático, indícale amablemente que solo manejas dudas de matemáticas y pide que reformule su consulta.',
       },
     });
 


### PR DESCRIPTION
## Summary
- refine `doubts` lambda so system instruction only covers math topics

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb9711b70832ea8a838658ae4dea9